### PR TITLE
Improved README + simplified content script permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,52 @@
 # butler
-Quora butler
+
 This is a Chrome extension that attempts to let you
 easily put "This is an answer, not a comment" text as a
-reply to a comment.
-
-For instructions on how to install and use,
+reply to a comment. For instructions on how to install and use,
 see 'doc/howto.html'.
+
+## Introduction<
+
+The _Quora Butler_ is a litle Chrome extension that gives you a 1-click way to send a reply to a comment. You can customize what that reply is, the default is "Thanks for the input. Did you want this to be an answer, instead of a comment?".
+    
+## Installation (For Devevelopment Purposes)
+
+Installation is clunky right now, sorry about that. Do these steps:
+
+- **Download the files**. Go to `https://github.com/kfishkin/butler`, and click the button that says 'Download ZIP'. Extract that zip file somewhere, note that it gave you a directory called `butler-master`.
+
+- **Install the extension**. In Chrome (this is Chrome only),
+    go to `chrome://extensions</code>`. Make sure you click the box that says 'Developer mode'.
+    
+    ![Developer mode](https://github.com/kfishkin/butler/blob/master/doc/pix/developer_mode.png)
+- Now click the button that says `Load unpacked extension...`. Navigate to the `butler-master` directory you just made, and select it. You should now see info about the butler appearing on that page:
+    ![Butler extension loaded](https://github.com/kfishkin/butler/blob/master/doc/pix/butler_extension_loaded.png)
+    
+- And you should also see the butler icon appear in your chrome toolbar:
+    ![Butler extension loaded](https://github.com/kfishkin/butler/blob/master/doc/pix/butler_icon_toolbar.png)
+
+## Use
+
+Once the extension has been installed, using it is, well, still kinda clunky, but here you go:
+
+- **Navigate to some Quora page with comments that you might want to reply to**. This could be some answer of yours with lots of comments, some notification about some comment added to an answer of yours, whatever. For example, here's one that Akshat Mahajan did for me to help in testing this plugin, you can see it at [this page](https://www.quora.com/What-are-the-most-funny-and-bizarre-road-signs-worth-slowing-down-for/answer/Ken-Fishkin). I've also added some other bogus comments so you can see how this work when there's more than one comment on an answer:
+
+    ![Comment before](https://github.com/kfishkin/butler/blob/master/doc/pix/comments_before.png)    
+
+- ** Click on the butler icon in the toolbar.** You will see a little form that looks like this:
+
+    ![Popup dialog](https://github.com/kfishkin/butler/blob/master/doc/pix/popup_dialog.png) 
+
+- Stuff in whatever text you'd like the 1-step reply to have for its reply. There is a default, you don't have to do this. In this case, I'll use the default.
+
+- Now, hit the 'Click to decorate' button. You will now see that little 'butler' icons now appear on your Quora page, one per comment:
+
+    ![Comments after decoration](https://github.com/kfishkin/butler/blob/master/doc/pix/comments_after_decoration.png) 
+
+- If you then click on one of these icons, it will 'reply' to the comment that it is next to, with the text you specified in the popup.
+
+For example, suppose we click on the icon by Akshat's comment. Then you will quickly see your page change to look like this:
+
+    ![After Reply](https://github.com/kfishkin/butler/blob/master/doc/pix/after_reply.png) 
+
+And there you have it! Try it out, let me know what you think, also it's on Github so I welcome improvements.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ easily put "This is an answer, not a comment" text as a
 reply to a comment. For instructions on how to install and use,
 see 'doc/howto.html'.
 
-## Introduction<
+## Introduction
 
 The _Quora Butler_ is a litle Chrome extension that gives you a 1-click way to send a reply to a comment. You can customize what that reply is, the default is "Thanks for the input. Did you want this to be an answer, instead of a comment?".
     
@@ -33,7 +33,7 @@ Once the extension has been installed, using it is, well, still kinda clunky, bu
 
     ![Comment before](https://github.com/kfishkin/butler/blob/master/doc/pix/comments_before.png)    
 
-- ** Click on the butler icon in the toolbar.** You will see a little form that looks like this:
+- **Click on the butler icon in the toolbar.** You will see a little form that looks like this:
 
     ![Popup dialog](https://github.com/kfishkin/butler/blob/master/doc/pix/popup_dialog.png) 
 
@@ -47,6 +47,6 @@ Once the extension has been installed, using it is, well, still kinda clunky, bu
 
 For example, suppose we click on the icon by Akshat's comment. Then you will quickly see your page change to look like this:
 
-    ![After Reply](https://github.com/kfishkin/butler/blob/master/doc/pix/after_reply.png) 
+![After Reply](https://github.com/kfishkin/butler/blob/master/doc/pix/after_reply.png) 
 
 And there you have it! Try it out, let me know what you think, also it's on Github so I welcome improvements.

--- a/background.js
+++ b/background.js
@@ -15,19 +15,19 @@ var replyText = 'Thanks for the input. Did you want this to be an answer, instea
  * listens for events coming from the popup.
  */
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
-  console.log('got request of ' + request + ', type = ' + request.type);
-  if ('Butler Popup' == request.type) {
-    console.log('got popup msg, txt = ' + request.replyText);
-    replyText = request.replyText;
-    // find all comments, add the butler button
-    // after all that don't already have it...
-    var comments = $("div.threaded_comment");
-    var timestamps = comments.find("span.timestamp[butler!='butler']");
-    timestamps.after(btn);
-    timestamps.attr('butler','butler');
-    $('img.butler_button').first().focus();
-  }
-  return true;
+    console.log('got request of ' + request + ', type = ' + request.type);
+    if ('Butler Popup' == request.type) {
+        console.log('got popup msg, txt = ' + request.replyText);
+        replyText = request.replyText;
+        // find all comments, add the butler button
+        // after all that don't already have it...
+        var comments = $("div.threaded_comment");
+        var timestamps = comments.find("span.timestamp[butler!='butler']");
+        timestamps.after(btn);
+        timestamps.attr('butler', 'butler');
+        $('img.butler_button').first().focus();
+    }
+    return true;
 });
 
 // find the URL of the butler button image.
@@ -37,43 +37,43 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 // http://stackoverflow.com/questions/3559781/google-chrome-extensions-cant-load-local-images-with-css
 var imgURL = chrome.extension.getURL('images/butler_small.jpg');
 var btn = $('<img>')
-  .addClass('butler_button')
-  .attr('src',imgURL)
-  .text('Butler')
-  .attr('title', replyText);
+    .addClass('butler_button')
+    .attr('src', imgURL)
+    .text('Butler')
+    .attr('title', replyText);
 
 /**
  * click handler for the butler button
  */
 btn.click(function(evt) {
-  var me = $(evt.target);
-  var cmt = me.parents('div.threaded_comment').first();
-  var replyBox = cmt.find('input.show_reply_box_link')
-  replyBox.focus();
-  // this will cause DOM re-writing. Wait for the input text
-  // area to show up, give it up to MAX_TRIES tries
-  var MAX_TRIES = 10;
-  var INTERVAL_IN_MS = 100;
-  var numTries = 0;
-  var timer = window.setInterval(function() {
-    var contentBox = cmt.find('div.content');
-    if (contentBox && contentBox.length > 0) {
-      window.clearInterval(timer);
-      contentBox.text(replyText);
-      var cancelLink = cmt.find('div.reply_submit_button_wrapper').children('span').children('a');
-      var replyLink = cmt.find('div.reply_submit_button_wrapper').children('a.submit_button');
-      // thanks to Stack Overflow:
-      // http://stackoverflow.com/questions/17819344/triggering-a-click-event-from-content-script-chrome-extension:
-      // 'jQuery's click trigger function does not trigger a non-jQuery DOM click listener (jsfiddle.net/k2W6M).'
-      // so you do it by sending a raw event to the DOM element:
-      replyLink.focus();
-      replyLink.get(0).dispatchEvent(new MouseEvent("click"));
-      cmt.focus();
-    } else if (numTries < MAX_TRIES) {
-      numTries++;
-    } else {
-      console.log('content box never showed, sorry');
-      window.clearInterval(timer);
-    }
-  }, INTERVAL_IN_MS);
+    var me = $(evt.target);
+    var cmt = me.parents('div.threaded_comment').first();
+    var replyBox = cmt.find('input.show_reply_box_link')
+    replyBox.focus();
+    // this will cause DOM re-writing. Wait for the input text
+    // area to show up, give it up to MAX_TRIES tries
+    var MAX_TRIES = 10;
+    var INTERVAL_IN_MS = 100;
+    var numTries = 0;
+    var timer = window.setInterval(function() {
+        var contentBox = cmt.find('div.content');
+        if (contentBox && contentBox.length > 0) {
+            window.clearInterval(timer);
+            contentBox.text(replyText);
+            var cancelLink = cmt.find('div.reply_submit_button_wrapper').children('span').children('a');
+            var replyLink = cmt.find('div.reply_submit_button_wrapper').children('a.submit_button');
+            // thanks to Stack Overflow:
+            // http://stackoverflow.com/questions/17819344/triggering-a-click-event-from-content-script-chrome-extension:
+            // 'jQuery's click trigger function does not trigger a non-jQuery DOM click listener (jsfiddle.net/k2W6M).'
+            // so you do it by sending a raw event to the DOM element:
+            replyLink.focus();
+            replyLink.get(0).dispatchEvent(new MouseEvent("click"));
+            cmt.focus();
+        } else if (numTries < MAX_TRIES) {
+            numTries++;
+        } else {
+            alert("Your Butler comment wasn't able to be sent. Sorry!"); // force an alert here so that user isn't confused about what happened.
+            window.clearInterval(timer);
+        }
+    }, INTERVAL_IN_MS);
 });

--- a/background.js
+++ b/background.js
@@ -15,19 +15,19 @@ var replyText = 'Thanks for the input. Did you want this to be an answer, instea
  * listens for events coming from the popup.
  */
 chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
-    console.log('got request of ' + request + ', type = ' + request.type);
-    if ('Butler Popup' == request.type) {
-        console.log('got popup msg, txt = ' + request.replyText);
-        replyText = request.replyText;
-        // find all comments, add the butler button
-        // after all that don't already have it...
-        var comments = $("div.threaded_comment");
-        var timestamps = comments.find("span.timestamp[butler!='butler']");
-        timestamps.after(btn);
-        timestamps.attr('butler', 'butler');
-        $('img.butler_button').first().focus();
-    }
-    return true;
+  console.log('got request of ' + request + ', type = ' + request.type);
+  if ('Butler Popup' == request.type) {
+      console.log('got popup msg, txt = ' + request.replyText);
+      replyText = request.replyText;
+      // find all comments, add the butler button
+      // after all that don't already have it...
+      var comments = $("div.threaded_comment");
+      var timestamps = comments.find("span.timestamp[butler!='butler']");
+      timestamps.after(btn);
+      timestamps.attr('butler', 'butler');
+      $('img.butler_button').first().focus();
+  }
+  return true;
 });
 
 // find the URL of the butler button image.
@@ -37,43 +37,43 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 // http://stackoverflow.com/questions/3559781/google-chrome-extensions-cant-load-local-images-with-css
 var imgURL = chrome.extension.getURL('images/butler_small.jpg');
 var btn = $('<img>')
-    .addClass('butler_button')
-    .attr('src', imgURL)
-    .text('Butler')
-    .attr('title', replyText);
+  .addClass('butler_button')
+  .attr('src', imgURL)
+  .text('Butler')
+  .attr('title', replyText);
 
 /**
  * click handler for the butler button
  */
 btn.click(function(evt) {
-    var me = $(evt.target);
-    var cmt = me.parents('div.threaded_comment').first();
-    var replyBox = cmt.find('input.show_reply_box_link')
-    replyBox.focus();
-    // this will cause DOM re-writing. Wait for the input text
-    // area to show up, give it up to MAX_TRIES tries
-    var MAX_TRIES = 10;
-    var INTERVAL_IN_MS = 100;
-    var numTries = 0;
-    var timer = window.setInterval(function() {
-        var contentBox = cmt.find('div.content');
-        if (contentBox && contentBox.length > 0) {
-            window.clearInterval(timer);
-            contentBox.text(replyText);
-            var cancelLink = cmt.find('div.reply_submit_button_wrapper').children('span').children('a');
-            var replyLink = cmt.find('div.reply_submit_button_wrapper').children('a.submit_button');
-            // thanks to Stack Overflow:
-            // http://stackoverflow.com/questions/17819344/triggering-a-click-event-from-content-script-chrome-extension:
-            // 'jQuery's click trigger function does not trigger a non-jQuery DOM click listener (jsfiddle.net/k2W6M).'
-            // so you do it by sending a raw event to the DOM element:
-            replyLink.focus();
-            replyLink.get(0).dispatchEvent(new MouseEvent("click"));
-            cmt.focus();
-        } else if (numTries < MAX_TRIES) {
-            numTries++;
-        } else {
-            alert("Your Butler comment wasn't able to be sent. Sorry!"); // force an alert here so that user isn't confused about what happened.
-            window.clearInterval(timer);
-        }
+  var me = $(evt.target);
+  var cmt = me.parents('div.threaded_comment').first();
+  var replyBox = cmt.find('input.show_reply_box_link')
+  replyBox.focus();
+  // this will cause DOM re-writing. Wait for the input text
+  // area to show up, give it up to MAX_TRIES tries
+  var MAX_TRIES = 10;
+  var INTERVAL_IN_MS = 100;
+  var numTries = 0;
+  var timer = window.setInterval(function() {
+    var contentBox = cmt.find('div.content');
+    if (contentBox && contentBox.length > 0) {
+      window.clearInterval(timer);
+      contentBox.text(replyText);
+      var cancelLink = cmt.find('div.reply_submit_button_wrapper').children('span').children('a');
+      var replyLink = cmt.find('div.reply_submit_button_wrapper').children('a.submit_button');
+      // thanks to Stack Overflow:
+      // http://stackoverflow.com/questions/17819344/triggering-a-click-event-from-content-script-chrome-extension:
+      // 'jQuery's click trigger function does not trigger a non-jQuery DOM click listener (jsfiddle.net/k2W6M).'
+      // so you do it by sending a raw event to the DOM element:
+      replyLink.focus();
+      replyLink.get(0).dispatchEvent(new MouseEvent("click"));
+      cmt.focus();
+      } else if (numTries < MAX_TRIES) {
+        numTries++;
+      } else {
+        alert("Your Butler comment wasn't able to be sent. Sorry!"); // force an alert here so that user isn't confused about what happened.
+        window.clearInterval(timer);
+      }
     }, INTERVAL_IN_MS);
 });

--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
   "content_scripts": [ {
     "js": [ "jquery-2.2.0.min.js", "background.js" ],
     "css": ["custom_styles.css"],
-    "matches": [ "http://www.quora.com/*", "https://www.quora.com/*"]
+    "matches": ["*://*.quora.com/*"]
   } ],
   "icons" : {
     "48" : "images/butler_48.png"

--- a/popup.html
+++ b/popup.html
@@ -20,9 +20,7 @@
   <body>
     The message for the reply:
     <br/>
-    <input type="text" id="reply_text"
-      value="Thanks for the input, but this should be an answer, not a comment.">
-    </input>
+    <input type="text" id="reply_text" value="Thanks for the input, but this should be an answer, not a comment." />
     <button id='invoke_butler'>Click to decorate</button>
   </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -7,45 +7,43 @@
  * will then receive this and do its thing.
  */
 document.addEventListener('DOMContentLoaded', function() {
-    var button = document.getElementById('invoke_butler');
-    button.addEventListener('click', function() {
-        var txt = document.getElementById('reply_text').value;
-        /*
-         * There are many ways to talk to the content script
-         * documented on the web, most of which don't work.
-         * The one that works I found at
-         * https://developer.chrome.com/extensions/tabs#method-sendMessage,
-         * as the doc says that you have to use tabs.sendMessage,
-         * not runtime.sendMessage, to talk to an extension
-         *
-         * This code will send the message to the active tab,
-         * which it assumes is the Quora tab.
-         * TODO: send to Quora tab(s), not the active tab. 
-         * Comment by Akshat: Added a string search for Quora in the URL. For stronger security, we could introduce 
-         *                    a regex match for https*://*.quora.com, but having trouble finding the right regex. :(
-         */
-        chrome.tabs.query({
-            active: true
-        }, function(tabs) {
-            // this is overly-general, there should never be
-            // more than one...
-            for (var i = 0; i < tabs.length; i++) {
-                if (tabs[i].url.indexOf("quora.com") !== -1) { // only operates on a URL containing quora.com
-                    var tab = tabs[i];
-                    console.log('tab.id = ' + tab.id);
-                    chrome.tabs.sendMessage(tab.id, {
-                            type: "Butler Popup",
-                            replyText: txt
-                        }, {},
-                        function(response) {
-                            console.log('sendMessage, response = ' + response);
-                            if (!response) {
-                                console.log('runtime err = ' + chrome.runtime.lastError);
-                                console.log('runtime err.msg = ' + chrome.runtime.lastError.message);
-                            }
-                        });
-                }
+  var button = document.getElementById('invoke_butler');
+  button.addEventListener('click', function() {
+    var txt = document.getElementById('reply_text').value;
+    /*
+     * There are many ways to talk to the content script
+     * documented on the web, most of which don't work.
+     * The one that works I found at
+     * https://developer.chrome.com/extensions/tabs#method-sendMessage,
+     * as the doc says that you have to use tabs.sendMessage,
+     * not runtime.sendMessage, to talk to an extension
+     *
+     * This code will send the message to the active tab,
+     * which it assumes is the Quora tab.
+ 
+     * Comment by Akshat: Added a string search for Quora in the URL.
+     */
+    chrome.tabs.query({
+      active: true
+    }, function(tabs) {
+      // this is overly-general, there should never be
+      // more than one...
+      for (var i = 0; i < tabs.length; i++) {
+        if (tabs[i].url.indexOf("quora.com") !== -1) { // only operates on a URL containing quora.com
+          var tab = tabs[i];
+          console.log('tab.id = ' + tab.id);
+          chrome.tabs.sendMessage(tab.id, {
+            type: "Butler Popup",
+            replyText: txt
+          }, {}, function(response) {
+            console.log('sendMessage, response = ' + response);
+            if (!response) {
+              console.log('runtime err = ' + chrome.runtime.lastError);
+              console.log('runtime err.msg = ' + chrome.runtime.lastError.message);
             }
-        });
+          });
+        }
+      }
     });
+  });
 });

--- a/popup.js
+++ b/popup.js
@@ -7,39 +7,45 @@
  * will then receive this and do its thing.
  */
 document.addEventListener('DOMContentLoaded', function() {
-  var button = document.getElementById('invoke_butler');
-  button.addEventListener('click', function() {
-    var txt = document.getElementById('reply_text').value;
-    /*
-     * There are many ways to talk to the content script
-     * documented on the web, most of which don't work.
-     * The one that works I found at
-     * https://developer.chrome.com/extensions/tabs#method-sendMessage,
-     * as the doc says that you have to use tabs.sendMessage,
-     * not runtime.sendMessage, to talk to an extension
-     *
-     * This code will send the message to the active tab,
-     * which it assumes is the Quora tab.
-     * TODO: send to Quora tab(s), not the active tab.
-     */
-    chrome.tabs.query( { active: true}, function (tabs) {
-      // this is overly-general, there should never be
-      // more than one...
-      for (var i = 0; i < tabs.length; i++) {
-        var tab = tabs[i];
-        console.log('tab.id = ' + tab.id);
-        chrome.tabs.sendMessage(tab.id,
-          { type: "Butler Popup", replyText : txt},
-          {},
-          function(response) {
-            console.log('sendMessage, response = ' + response);
-            if (!response) {
-              console.log('runtime err = ' + chrome.runtime.lastError);
-              console.log('runtime err.msg = '
-                + chrome.runtime.lastError.message);
+    var button = document.getElementById('invoke_butler');
+    button.addEventListener('click', function() {
+        var txt = document.getElementById('reply_text').value;
+        /*
+         * There are many ways to talk to the content script
+         * documented on the web, most of which don't work.
+         * The one that works I found at
+         * https://developer.chrome.com/extensions/tabs#method-sendMessage,
+         * as the doc says that you have to use tabs.sendMessage,
+         * not runtime.sendMessage, to talk to an extension
+         *
+         * This code will send the message to the active tab,
+         * which it assumes is the Quora tab.
+         * TODO: send to Quora tab(s), not the active tab. 
+         * Comment by Akshat: Added a string search for Quora in the URL. For stronger security, we could introduce 
+         *                    a regex match for https*://*.quora.com, but having trouble finding the right regex. :(
+         */
+        chrome.tabs.query({
+            active: true
+        }, function(tabs) {
+            // this is overly-general, there should never be
+            // more than one...
+            for (var i = 0; i < tabs.length; i++) {
+                if (tabs[i].url.indexOf("quora.com") !== -1) { // only operates on a URL containing quora.com
+                    var tab = tabs[i];
+                    console.log('tab.id = ' + tab.id);
+                    chrome.tabs.sendMessage(tab.id, {
+                            type: "Butler Popup",
+                            replyText: txt
+                        }, {},
+                        function(response) {
+                            console.log('sendMessage, response = ' + response);
+                            if (!response) {
+                                console.log('runtime err = ' + chrome.runtime.lastError);
+                                console.log('runtime err.msg = ' + chrome.runtime.lastError.message);
+                            }
+                        });
+                }
             }
-          });
-      }
+        });
     });
-  });
 });


### PR DESCRIPTION
I moved the contents of `how_to.html` to the README with Markdown enabled, so that it's easier to read. I also simplified the content script permissions, so that it now targets any subdomain on Quora and protocol - now you can have the same functionality on blogs such as [Quoran of the Week](https://quoranoftheweek.quora.com/).

Also went ahead and resolved the issue in `popup.js` where you mentioned that we need to only operate on the Quora tab rather than iterate through all of them. I added an if condition that performs a substring check for `quora.com` on the tab before going through.
